### PR TITLE
feature: add embedded 4four.io metronome above video component

### DIFF
--- a/apps/fretonator-web/src/app/common/fretonator/fretonator.component.html
+++ b/apps/fretonator-web/src/app/common/fretonator/fretonator.component.html
@@ -2,7 +2,23 @@
 
 <app-fretboard [fretMap]="fretMap" [mode]="mode"></app-fretboard>
 
-<ng-container *ngIf="note | symbolToNoteObj: noteExtender | getJamTrack: mode">
+<div class="metronome-container">
+  <button (click)="toggleMetronomeIframe()" class="metronome-btn">
+    {{ isMetronomeVisible ? 'Hide Metronome' : 'Show Metronome' }}
+  </button>
+  <div *ngIf="isMetronomeVisible" class="iframe-wrapper">
+    <iframe
+      src="https://4four.io/embed/metronome"
+      width="400"
+      height="680"
+      frameborder="0"
+    >
+      <a href="https://4four.io/metronome"> Metronome </a>
+    </iframe>
+  </div>
+</div>
+
+<ng-container>
   <app-video-loader
     [jamTrack]="note | symbolToNoteObj: noteExtender | getJamTrack: mode"
   ></app-video-loader>

--- a/apps/fretonator-web/src/app/common/fretonator/fretonator.component.scss
+++ b/apps/fretonator-web/src/app/common/fretonator/fretonator.component.scss
@@ -109,3 +109,26 @@
   margin-bottom: 1rem;
   align-self: flex-start;
 }
+
+.metronome-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  margin-top: 20px;
+}
+
+.metronome-btn {
+  display: flex;
+  flex-direction: column;
+  @include hard_button_base();
+  align-self: unset;
+}
+
+.iframe-wrapper {
+  margin-top: 20px;
+  display: flex;
+  justify-content: center;
+  width: 100%;
+}
+

--- a/apps/fretonator-web/src/app/common/fretonator/fretonator.component.ts
+++ b/apps/fretonator-web/src/app/common/fretonator/fretonator.component.ts
@@ -31,6 +31,7 @@ export class FretonatorComponent {
   scaleDegreesToggleText = ScaleDegreesToggleText.hidden;
   showTheoreticalScalesInfo = false;
   theoreticalScalesToggleText = TheoreticalScalesToggleText.hidden;
+  isMetronomeVisible = false;
 
   constructor(private globalService: GlobalService) {
   }
@@ -48,5 +49,9 @@ export class FretonatorComponent {
   enharmonicLinkClick() {
     this.toggleTheoreticalScaleInfo();
     this.globalService.getScrollTarget().scrollIntoView();
+  }
+
+  toggleMetronomeIframe() {
+    this.isMetronomeVisible = !this.isMetronomeVisible;
   }
 }


### PR DESCRIPTION
# Summary

I've been using Fretonator a lot lately and was pleased to see that it was an Angular app! I'd like to bring this simple, hidden metronome embed up for consideration as an add-on to the existing site. I loved the simple look of the `Learn about the 7 patterns` button and thought using it might be a nice way to break the sections up. I know the light theme of the metronome embed can be a bit abrasive on the dark theme, but open to suggestions!

* adds metronome iframe wrapper from 4four.io and a show/hide button styled like the `Learn about the 7 patterns` button.

## Screenshots: 

<img width="1453" alt="Screenshot 2024-09-12 at 6 13 44 PM" src="https://github.com/user-attachments/assets/4f732187-2b11-4dd6-94cb-0ffc19b58ce7">
<img width="2056" alt="Screenshot 2024-09-12 at 6 13 02 PM" src="https://github.com/user-attachments/assets/30b5cc32-b9de-4d6f-8e0d-b0f05f3cd07e">

![localhost_63294_(iPhone 14 Pro Max) (1)](https://github.com/user-attachments/assets/46d593c2-8830-4830-8795-2d0e7c6267e5)
![localhost_63294_(iPhone 14 Pro Max)](https://github.com/user-attachments/assets/ed148008-4b53-4ad1-89fa-433caf1e627e)
